### PR TITLE
Added hook for newly added SetMapToDigSitePosition API function

### DIFF
--- a/src/MapAdapter.lua
+++ b/src/MapAdapter.lua
@@ -24,6 +24,9 @@ function MapAdapter:Initialize()
     self:HookSetMapToFunction("SetMapToQuestZone")
     self:HookSetMapToFunction("SetMapToMapListIndex")
     self:HookSetMapToFunction("SetMapToAutoMapNavigationTargetPosition")
+	if SetMapToDigSitePosition then -- added with Greymoore update. Not available in Harrowstorm
+		self:HookSetMapToFunction("SetMapToDigSitePosition")
+	end
     self:HookSetMapToFunction("SetMapToPlayerLocation")
     self:HookSetMapToFunction("ProcessMapClick", true, true) -- Returning is done via clicking already
     self:HookSetMapToFunction("SetMapFloor", true)


### PR DESCRIPTION
With the new Greymoore update and the new antiquity system (currently on PTS) ZOS has added the new API function SetMapToDigSitePosition, which sets the map to whatever location the antiquity can be found.

I have added a check if that function exists (it doesn't on live) and a hook to that function if it exists.