### PR TITLE
Allow getting map measurements from specific mapIDs

### DIFF
--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -108,7 +108,7 @@ function TamrielOMeter:GetMapMeasurementByMapID(mapId)
 
     if (not measurement) then 
         -- try to calculate the measurement if it does not yet exist
-        self:CalculateMapMeasurement()
+        self:CalculateMapMeasurement(mapId)
     end
 
     return self.measurements[mapId]

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -119,7 +119,7 @@ function TamrielOMeter:GetCurrentMapMeasurement()
     local measurement = self:GetMeasurement(mapId)
 
     if (not measurement) then
-        -- try to calculate the measurement if it does not yet exist
+        -- try to calculate the measurement if they are not yet available
         self:CalculateMapMeasurement()
     end
 
@@ -146,8 +146,6 @@ function TamrielOMeter:TryCalculateRootMapMeasurement(rootMapIndex)
 
     return measurement
 end
-
-
 
 
 function TamrielOMeter:CalculateMapMeasurement(mapId)

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -115,7 +115,7 @@ function TamrielOMeter:GetCurrentMapMeasurement()
     return self.measurements[mapId]
 end
 
-function TamrielOMeter:GetMapMeasurementByMapID(mapId)
+function TamrielOMeter:GetMapMeasurementByMapId(mapId)
     local measurement = self:GetMeasurement(mapId)
 
     if (not measurement) then 
@@ -148,9 +148,9 @@ function TamrielOMeter:TryCalculateRootMapMeasurement(rootMapIndex)
 end
 
 
-function TamrielOMeter:CalculateMapMeasurement(providedMapId)
+function TamrielOMeter:CalculateMapMeasurement(mapId)
     local adapter = self.adapter
-    local mapId = providedMapId
+    local mapId = mapId
 
     -- if no valid mapId was provided, assume current map
     if (mapId == nil or type(mapId) ~= "number") then

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -103,24 +103,24 @@ function TamrielOMeter:ClearCurrentMapMeasurement()
     end
 end
 
+function TamrielOMeter:GetCurrentMapMeasurement()
+    local mapId = self.adapter:GetCurrentMapIdentifier()
+    local measurement = self:GetMeasurement(mapId)
+
+    if (not measurement) then
+        -- try to calculate the measurement if it does not yet exist
+        self:CalculateMapMeasurement()
+    end
+
+    return self.measurements[mapId]
+end
+
 function TamrielOMeter:GetMapMeasurementByMapID(mapId)
     local measurement = self:GetMeasurement(mapId)
 
     if (not measurement) then 
         -- try to calculate the measurement if it does not yet exist
         self:CalculateMapMeasurement(mapId)
-    end
-
-    return self.measurements[mapId]
-end
-
-function TamrielOMeter:GetCurrentMapMeasurement()
-    local mapId = self.adapter:GetCurrentMapIdentifier()
-    local measurement = self:GetMeasurement(mapId)
-
-    if (not measurement) then
-        -- try to calculate the measurement if they are not yet available
-        self:CalculateMapMeasurement()
     end
 
     return self.measurements[mapId]

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -148,14 +148,16 @@ function TamrielOMeter:TryCalculateRootMapMeasurement(rootMapIndex)
 end
 
 
-function TamrielOMeter:CalculateMapMeasurement(mapId)
+function TamrielOMeter:CalculateMapMeasurement(providedMapId)
     local adapter = self.adapter
+
+    local mapId = providedMapId
 
     -- if no valid mapId was provided, assume current map
     if (mapId == nil or type(mapId) ~= "number") then
 
         -- no need to take measurements more than once
-        local mapId = adapter:GetCurrentMapIdentifier()
+        mapId = adapter:GetCurrentMapIdentifier()
 
     end
 

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -150,7 +150,6 @@ end
 
 function TamrielOMeter:CalculateMapMeasurement(providedMapId)
     local adapter = self.adapter
-
     local mapId = providedMapId
 
     -- if no valid mapId was provided, assume current map

--- a/src/TamrielOMeter.lua
+++ b/src/TamrielOMeter.lua
@@ -103,12 +103,23 @@ function TamrielOMeter:ClearCurrentMapMeasurement()
     end
 end
 
+function TamrielOMeter:GetMapMeasurementByMapID(mapId)
+    local measurement = self:GetMeasurement(mapId)
+
+    if (not measurement) then 
+        -- try to calculate the measurement if it does not yet exist
+        self:CalculateMapMeasurement()
+    end
+
+    return self.measurements[mapId]
+end
+
 function TamrielOMeter:GetCurrentMapMeasurement()
     local mapId = self.adapter:GetCurrentMapIdentifier()
     local measurement = self:GetMeasurement(mapId)
 
     if (not measurement) then
-        -- try to calculate the measurement if they are not yet available
+        -- try to calculate the measurement if it does not yet exist
         self:CalculateMapMeasurement()
     end
 
@@ -136,11 +147,21 @@ function TamrielOMeter:TryCalculateRootMapMeasurement(rootMapIndex)
     return measurement
 end
 
-function TamrielOMeter:CalculateMapMeasurement()
+
+
+
+function TamrielOMeter:CalculateMapMeasurement(mapId)
     local adapter = self.adapter
 
-    -- no need to take measurements more than once
-    local mapId = adapter:GetCurrentMapIdentifier()
+    -- if no valid mapId was provided, assume current map
+    if (mapId == nil or type(mapId) ~= "number") then
+
+        -- no need to take measurements more than once
+        local mapId = adapter:GetCurrentMapIdentifier()
+
+    end
+
+
     if(mapId == 0 or self:GetMeasurement(mapId)) then return false, SET_MAP_RESULT_CURRENT_MAP_UNCHANGED end
 
     local offsetX, offsetY, scaleX, scaleY = adapter:GetUniversallyNormalizedMapInfo(mapId)

--- a/src/api.lua
+++ b/src/api.lua
@@ -35,6 +35,11 @@ function lib:GetCurrentMapMeasurement()
     return internal.meter:GetCurrentMapMeasurement()
 end
 
+--- Returns a Measurement object for specified map ID or nil if the measurement could not be calculated for some reason.
+function lib:GetMapMeasurementByMapID(mapId)
+    return internal.meter:GetMapMeasurementByMapID(mapId)
+end
+
 --- Returns the mapIndex and zoneIndex of the parent zone for the currently set map.
 --- return[1] number - The mapIndex of the parent zone
 --- return[2] number - The zoneIndex of the parent zone

--- a/src/api.lua
+++ b/src/api.lua
@@ -36,8 +36,8 @@ function lib:GetCurrentMapMeasurement()
 end
 
 --- Returns a Measurement object for specified map ID or nil if the measurement could not be calculated for some reason.
-function lib:GetMapMeasurementByMapID(mapId)
-    return internal.meter:GetMapMeasurementByMapID(mapId)
+function lib:GetMapMeasurementByMapId(mapId)
+    return internal.meter:GetMapMeasurementByMapId(mapId)
 end
 
 --- Returns the mapIndex and zoneIndex of the parent zone for the currently set map.


### PR DESCRIPTION
usecase: being able to get the measurements of a certain map, whilst the player is currently looking at another map (before, only current map's measurements could be received)