### PR TITLE
Fixed typo and world size calculation

### DIFF
--- a/src/LibGPS.txt
+++ b/src/LibGPS.txt
@@ -1,12 +1,11 @@
 ## Title: LibGPS
 ## Author: sirinsidiator & votan
 ## Contributors: Shinni
-## Version: @VERSION_NUMBER@
-## AddOnVersion: @BUILD_NUMBER@
-## APIVersion: @API_VERSION@
+## Version: 3.3.1
+## AddOnVersion: 70
+## APIVersion: 101038 101039
 ## IsLibrary: true
 ## DependsOn: LibMapPing>=900 LibDebugLogger>=196 LibChatMessage>=100
-## SavedVariables: LibGPS_Data
 ##
 ## This Add-on is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates.
 ## The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries.

--- a/src/LibGPS.txt
+++ b/src/LibGPS.txt
@@ -1,9 +1,9 @@
 ## Title: LibGPS
 ## Author: sirinsidiator & votan
 ## Contributors: Shinni
-## Version: 3.3.1
-## AddOnVersion: 70
-## APIVersion: 101038 101039
+## Version: @VERSION_NUMBER@
+## AddOnVersion: @BUILD_NUMBER@
+## APIVersion: @API_VERSION@
 ## IsLibrary: true
 ## DependsOn: LibMapPing>=900 LibDebugLogger>=196 LibChatMessage>=100
 ##

--- a/src/MapAdapter.lua
+++ b/src/MapAdapter.lua
@@ -1,4 +1,4 @@
--- LibGPS3 & its files © sirinsidiator                          --
+-- LibGPS3 & its files Â© sirinsidiator                          --
 -- Distributed under The Artistic License 2.0 (see LICENSE)     --
 ------------------------------------------------------------------
 
@@ -41,7 +41,7 @@ function MapAdapter:HookSetMapToFunction(funcName, returnToInitialMap, skipSecon
     self.original[funcName] = orgFunction
     _G[funcName] = function(...)
         local result = orgFunction(...)
-        if(result ~= SET_MAP_RESULT_MAP_FAILED and not lib:GetCurrentMapMeasurement()) then
+        if(result ~= SET_MAP_RESULT_FAILED and not lib:GetCurrentMapMeasurement()) then
             logger:Debug(funcName)
 
             local success, mapResult = lib:CalculateMapMeasurement(returnToInitialMap)


### PR DESCRIPTION
Especially for sub-zones without own map:
If the measure point leaves the sub-zone, you get wrong sizes.
As the waypoint is not required for measure points anymore, four measure points are used and the highest TARDIS factor is used.
Additional the difference between the corrected world posiition and the real world position is used to create an identifier to detect those sub-zone dispositions.
On "normal" maps, the difference is zero.